### PR TITLE
Make WebSocket URL optional and change URL building logic

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+### What
+
+Describe the scope of changes in this pull request.
+
+### Why
+
+Describe the reasoning behind this pull request.
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install --save @speechly/browser-client
 Start using the client:
 
 ```typescript
-import { Client, ISegment } from '@speechly/browser-client'
+import { Client, Segment } from '@speechly/browser-client'
 
 // Create a new Client. appId and language are configured in the dashboard.
 const client = new Client({
@@ -35,7 +35,7 @@ client.initialize((err?: Error) => {
 })
 
 // React to the phrases received from the API
-client.onSegmentChange((segment: ISegment) => {
+client.onSegmentChange((segment: Segment) => {
   console.log('Received new segment from the API:', segment.intent, segment.entities, segment.words, segment.isFinal)
 })
 
@@ -53,7 +53,7 @@ client.startContext((err?: Error) => {
 
 ## Documentation
 
-Check the detailed API documentation in the [docs directory](docs/modules/_speechly_d_.md).
+You can find the detailed API documentation in [GitHub repository](https://github.com/speechly/browser-client/blob/master/docs/modules/_speechly_d_.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## speechly-browser-client
 
+[![npm version](https://badge.fury.io/js/%40speechly%2Fbrowser-client.svg)](https://badge.fury.io/js/%40speechly%2Fbrowser-client)
+
 This repository contains source code for the browser client for Speechly SLU API. Speechly allows you to easily build applications with voice-enabled UIs.
 
 ## Usage

--- a/docs/classes/_speechly_d_.client.md
+++ b/docs/classes/_speechly_d_.client.md
@@ -69,7 +69,7 @@ ___
 
 ###  initialize
 
-▸ **initialize**(`cb`: [ErrorCallback](../modules/_speechly_d_.md#errorcallback)): *void*
+▸ **initialize**(`cb?`: [ErrorCallback](../modules/_speechly_d_.md#errorcallback)): *void*
 
 Defined in speechly.d.ts:29
 
@@ -79,7 +79,7 @@ Initializes the client, by initializing the microphone and establishing connecti
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`cb` | [ErrorCallback](../modules/_speechly_d_.md#errorcallback) | the callback which is invoked when the initialization is complete.  |
+`cb?` | [ErrorCallback](../modules/_speechly_d_.md#errorcallback) | the callback which is invoked when the initialization is complete.  |
 
 **Returns:** *void*
 
@@ -231,7 +231,7 @@ ___
 
 ###  startContext
 
-▸ **startContext**(`cb`: [ContextCallback](../modules/_speechly_d_.md#contextcallback)): *void*
+▸ **startContext**(`cb?`: [ContextCallback](../modules/_speechly_d_.md#contextcallback)): *void*
 
 Defined in speechly.d.ts:39
 
@@ -241,7 +241,7 @@ Starts a new SLU context by sending a start context event to the API and unmutin
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`cb` | [ContextCallback](../modules/_speechly_d_.md#contextcallback) | the callback which is invoked when the context start was acknowledged by the API.  |
+`cb?` | [ContextCallback](../modules/_speechly_d_.md#contextcallback) | the callback which is invoked when the context start was acknowledged by the API.  |
 
 **Returns:** *void*
 
@@ -249,7 +249,7 @@ ___
 
 ###  stopContext
 
-▸ **stopContext**(`cb`: [ContextCallback](../modules/_speechly_d_.md#contextcallback)): *void*
+▸ **stopContext**(`cb?`: [ContextCallback](../modules/_speechly_d_.md#contextcallback)): *void*
 
 Defined in speechly.d.ts:44
 
@@ -259,6 +259,6 @@ Stops current SLU context by sending a stop context event to the API and muting 
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`cb` | [ContextCallback](../modules/_speechly_d_.md#contextcallback) | the callback which is invoked when the context stop was acknowledged by the API.  |
+`cb?` | [ContextCallback](../modules/_speechly_d_.md#contextcallback) | the callback which is invoked when the context stop was acknowledged by the API.  |
 
 **Returns:** *void*

--- a/docs/interfaces/_speechly_d_.clientoptions.md
+++ b/docs/interfaces/_speechly_d_.clientoptions.md
@@ -17,7 +17,7 @@ The options which can be used to configure the client.
 * [deviceId](_speechly_d_.clientoptions.md#optional-deviceid)
 * [language](_speechly_d_.clientoptions.md#language)
 * [sampleRate](_speechly_d_.clientoptions.md#optional-samplerate)
-* [url](_speechly_d_.clientoptions.md#url)
+* [url](_speechly_d_.clientoptions.md#optional-url)
 
 ## Properties
 
@@ -71,9 +71,9 @@ The sample rate of the audio to use.
 
 ___
 
-###  url
+### `Optional` url
 
-• **url**: *string*
+• **url**? : *undefined | string*
 
 Defined in speechly.d.ts:108
 

--- a/etc/browser-client.api.md
+++ b/etc/browser-client.api.md
@@ -28,7 +28,7 @@ export interface ClientOptions {
     deviceId?: string;
     language: string;
     sampleRate?: number;
-    url: string;
+    url?: string;
 }
 
 // @public

--- a/etc/browser-client.api.md
+++ b/etc/browser-client.api.md
@@ -8,7 +8,7 @@
 export class Client {
     constructor(options: ClientOptions);
     close(cb?: ErrorCallback): void;
-    initialize(cb: ErrorCallback): void;
+    initialize(cb?: ErrorCallback): void;
     onEntity(cb: EntityCallback): void;
     onIntent(cb: IntentCallback): void;
     onSegmentChange(cb: SegmentChangeCallback): void;
@@ -17,8 +17,8 @@ export class Client {
     onTentativeIntent(cb: IntentCallback): void;
     onTentativeTranscript(cb: TentativeTranscriptCallback): void;
     onTranscript(cb: TranscriptCallback): void;
-    startContext(cb: ContextCallback): void;
-    stopContext(cb: ContextCallback): void;
+    startContext(cb?: ContextCallback): void;
+    stopContext(cb?: ContextCallback): void;
     }
 
 // @public

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,182 +1,183 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <script src="speechly.js"></script>
+    <script type="application/javascript">
+      // Configure Speechly client.
+      const client = new speechly.Client({
+        appId: 'your-app-id',
+        language: 'en-US'
+      })
 
-<head>
-  <script src="speechly.js"></script>
-  <script type="application/javascript">
-    // Configure Speechly client.
-    const client = new speechly.Client({
-      appId: 'your-app-id',
-      language: 'en-US',
-      url: 'api.speechly.com/websocket',
-    });
+      window.onload = () => {
+        // High-level API, that you can use to react to segment changes.
+        client.onSegmentChange(segment => {
+          updateWords(segment.words)
+          updateEntities(segment.entities)
 
-    window.onload = () => {
-      // High-level API, that you can use to react to segment changes.
-      client.onSegmentChange((segment) => {
-        updateWords(segment.words);
-        updateEntities(segment.entities);
+          if (segment.isFinalized) {
+            updateReady(segment.contextId, true)
+          }
+        })
 
-        if (segment.isFinalized) {
-          updateReady(segment.contextId, true);
-        }
-      });
+        // This is low-level API, that you can use to react to tentative events.
+        client.onTentativeTranscript((cid, sid, words, transcript) =>
+          log('tentative_transcript', cid, sid, { words, transcript })
+        )
+        client.onTentativeEntities((cid, sid, entities) => log('tentative_entities', cid, sid, { entities }))
+        client.onTentativeIntent((cid, sid, intent) => log('tentative_intent', cid, sid, { intent }))
 
-      // This is low-level API, that you can use to react to tentative events.
-      client.onTentativeTranscript((cid, sid, words, transcript) => log('tentative_transcript', cid, sid, { words, transcript }));
-      client.onTentativeEntities((cid, sid, entities) => log('tentative_entities', cid, sid, { entities }));
-      client.onTentativeIntent((cid, sid, intent) => log('tentative_intent', cid, sid, { intent }));
+        // This is low-level API, that you can use to react to final events.
+        client.onTranscript((cid, sid, word) => log('transcript', cid, sid, { word }))
+        client.onEntity((cid, sid, entity) => log('entity', cid, sid, { entity }))
+        client.onIntent((cid, sid, intent) => log('intent', cid, sid, { intent }))
 
-      // This is low-level API, that you can use to react to final events.
-      client.onTranscript((cid, sid, word) => log('transcript', cid, sid, { word }));
-      client.onEntity((cid, sid, entity) => log('entity', cid, sid, { entity }));
-      client.onIntent((cid, sid, intent) => log('intent', cid, sid, { intent }));
+        // Initialize the client.
+        client.initialize(err => {
+          if (err) {
+            console.error('Error initializing Speechly client:', err)
+            return
+          }
+        })
 
-      // Initialize the client.
-      client.initialize((err) => {
-        if (err) {
-          console.error('Error initializing Speechly client:', err);
-          return;
-        }
-      });
+        // Use the "Record" button for recording.
+        const recordDiv = document.getElementById('record')
+        recordDiv.addEventListener('mousedown', startRecording)
+        recordDiv.addEventListener('mouseup', stopRecording)
 
-      // Use the "Record" button for recording.
-      const recordDiv = document.getElementById('record');
-      recordDiv.addEventListener('mousedown', startRecording);
-      recordDiv.addEventListener('mouseup', stopRecording);
+        // Use disconnect button to disconnect.
+        const dcDiv = document.getElementById('disconnect')
+        dcDiv.addEventListener('click', () => client.close())
 
-      // Use disconnect button to disconnect.
-      const dcDiv = document.getElementById('disconnect');
-      dcDiv.addEventListener('click', () => client.close());
+        // Update client status on the page.
+        client.onStateChange(state => {
+          if (state < speechly.ClientState.Connected) {
+            recordDiv.setAttribute('disabled', true)
+            dcDiv.setAttribute('disabled', true)
+          } else {
+            recordDiv.removeAttribute('disabled')
+            dcDiv.removeAttribute('disabled')
+          }
 
-      // Update client status on the page.
-      client.onStateChange((state) => {
-        if (state < speechly.ClientState.Connected) {
-          recordDiv.setAttribute('disabled', true);
-          dcDiv.setAttribute('disabled', true);
-        } else {
-          recordDiv.removeAttribute('disabled');
-          dcDiv.removeAttribute('disabled');
-        }
-
-        document.getElementById('status').innerHTML = speechly.stateToString(state);
-      });
-    };
-
-    function startRecording(event) {
-      event.preventDefault();
-
-      client.startContext((err, contextId) => {
-        if (err) {
-          console.error('Could not start recording', err);
-          return;
-        }
-
-        reset(contextId);
-      });
-    }
-
-    function stopRecording(event) {
-      event.preventDefault();
-
-      client.stopContext((err) => {
-        if (err) {
-          console.error('Could not stop recording', err);
-          return;
-        }
-      });
-    }
-
-    function updateWords(words) {
-      const textDiv = document.getElementById('transcript-words');
-      textDiv.innerHTML = words.map(word => word.isFinal ? `<b>${word.value}</b>` : word.value).join(' ');
-
-      const wordsDiv = document.getElementById('transcript-list');
-      wordsDiv.innerHTML = words
-        .map(word => word.isFinal ? `<li><b>${word.value}</b></li>` : `<li>${word.value}</li>`).join('');
-    }
-
-    function updateEntities(entities) {
-      const entitiesDiv = document.getElementById('entities-list');
-      entitiesDiv.innerHTML = entities.map((entity) => {
-        const t = `${entity.type} - ${entity.value} [${entity.startPosition} - ${entity.endPosition}]`;
-        if (entity.isFinal) {
-          return `<li><b>${t}</b></li>`
-        }
-        return `<li>${t}</li>`;
-      }).join('');
-    }
-
-    function updateReady(contextId, isReady) {
-      const readyDiv = document.getElementById('final');
-
-      if (isReady) {
-        readyDiv.innerHTML = `<b>Context</b> ${contextId} Done!`;
-      } else {
-        readyDiv.innerHTML = `<b>Context</b> ${contextId}`;
+          document.getElementById('status').innerHTML = speechly.stateToString(state)
+        })
       }
-    }
 
-    function log(type, contextId, segmentId, data) {
-      const logDiv = document.getElementById('log-list');
-      logDiv.innerHTML = `<tr>
+      function startRecording(event) {
+        event.preventDefault()
+
+        client.startContext((err, contextId) => {
+          if (err) {
+            console.error('Could not start recording', err)
+            return
+          }
+
+          reset(contextId)
+        })
+      }
+
+      function stopRecording(event) {
+        event.preventDefault()
+
+        client.stopContext(err => {
+          if (err) {
+            console.error('Could not stop recording', err)
+            return
+          }
+        })
+      }
+
+      function updateWords(words) {
+        const textDiv = document.getElementById('transcript-words')
+        textDiv.innerHTML = words.map(word => (word.isFinal ? `<b>${word.value}</b>` : word.value)).join(' ')
+
+        const wordsDiv = document.getElementById('transcript-list')
+        wordsDiv.innerHTML = words
+          .map(word => (word.isFinal ? `<li><b>${word.value}</b></li>` : `<li>${word.value}</li>`))
+          .join('')
+      }
+
+      function updateEntities(entities) {
+        const entitiesDiv = document.getElementById('entities-list')
+        entitiesDiv.innerHTML = entities
+          .map(entity => {
+            const t = `${entity.type} - ${entity.value} [${entity.startPosition} - ${entity.endPosition}]`
+            if (entity.isFinal) {
+              return `<li><b>${t}</b></li>`
+            }
+            return `<li>${t}</li>`
+          })
+          .join('')
+      }
+
+      function updateReady(contextId, isReady) {
+        const readyDiv = document.getElementById('final')
+
+        if (isReady) {
+          readyDiv.innerHTML = `<b>Context</b> ${contextId} Done!`
+        } else {
+          readyDiv.innerHTML = `<b>Context</b> ${contextId}`
+        }
+      }
+
+      function log(type, contextId, segmentId, data) {
+        const logDiv = document.getElementById('log-list')
+        logDiv.innerHTML =
+          `<tr>
           <td>${contextId}</td>
           <td>${segmentId}</td>
           <td>${type}</td>
           <td>${JSON.stringify(data)}</td>
-        </tr>` + logDiv.innerHTML;
-    }
+        </tr>` + logDiv.innerHTML
+      }
 
-    function reset(contextId) {
-      updateReady(contextId, false);
+      function reset(contextId) {
+        updateReady(contextId, false)
 
-      document.getElementById('transcript-words').innerHTML = '';
-      document.getElementById('transcript-list').innerHTML = '';
-      document.getElementById('log-list').innerHTML = '';
-      document.getElementById('entities-list').innerHTML = '';
-    }
-  </script>
-</head>
+        document.getElementById('transcript-words').innerHTML = ''
+        document.getElementById('transcript-list').innerHTML = ''
+        document.getElementById('log-list').innerHTML = ''
+        document.getElementById('entities-list').innerHTML = ''
+      }
+    </script>
+  </head>
 
-<body>
-  <h1>Speechly demo</h1>
+  <body>
+    <h1>Speechly demo</h1>
 
-  <div>
-    <h3 id="status">Disconnected</h3>
-    <button id="record" disabled="true">Record</button>
-    <button id="disconnect" disabled="true">Disconnect</button>
-    <p id="final"></p>
-  </div>
+    <div>
+      <h3 id="status">Disconnected</h3>
+      <button id="record" disabled="true">Record</button>
+      <button id="disconnect" disabled="true">Disconnect</button>
+      <p id="final"></p>
+    </div>
 
-  <div id="transcript">
-    <h3>Transcript</h3>
-    <p id="transcript-words"></p>
+    <div id="transcript">
+      <h3>Transcript</h3>
+      <p id="transcript-words"></p>
 
-    <h3>Words</h3>
-    <ol id="transcript-list"></ol>
-  </div>
+      <h3>Words</h3>
+      <ol id="transcript-list"></ol>
+    </div>
 
-  <div id="entities">
-    <h3>Entities</h3>
-    <ol id="entities-list">
-    </ol>
-  </div>
+    <div id="entities">
+      <h3>Entities</h3>
+      <ol id="entities-list"></ol>
+    </div>
 
-  <div id="log">
-    <h3>Log</h3>
-    <table>
-      <thead>
-        <tr>
-          <th>Utterance ID</th>
-          <th>Segment ID</th>
-          <th>Event type</th>
-          <th>Event data</th>
-        </tr>
-      </thead>
-      <tbody id="log-list">
-      </tbody>
-    </table>
-  </div>
-</body>
-
+    <div id="log">
+      <h3>Log</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Utterance ID</th>
+            <th>Segment ID</th>
+            <th>Event type</th>
+            <th>Event data</th>
+          </tr>
+        </thead>
+        <tbody id="log-list"></tbody>
+      </table>
+    </div>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,8 +1,27 @@
 {
   "name": "@speechly/browser-client",
-  "private": true,
   "version": "0.0.1",
   "description": "Browser client for Speechly API",
+  "private": true,
+  "keywords": [
+    "client",
+    "voice",
+    "speech",
+    "slu",
+    "spoken language understanding",
+    "speechly",
+    "asr",
+    "nlp",
+    "natural language processing",
+    "nlu",
+    "natural language understanding",
+    "natural language",
+    "vui",
+    "voice ui",
+    "voice user interface",
+    "multimodal",
+    "speech recognition"
+  ],
   "scripts": {
     "all": "npm run lint && npm run test && npm run dist && npm run docs",
     "build": "WEBPACK_MODE='prd' npx webpack --config ./config/webpack.config.js",
@@ -18,7 +37,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com/speechly/browser-client"
+    "url": "git+https://github.com/speechly/browser-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/speechly/browser-client/issues"
   },
   "main": "./dist/speechly.js",
   "module": "./dist/speechly.js",
@@ -26,8 +48,7 @@
   "author": "Speechly",
   "license": "MIT",
   "dependencies": {
-    "locale-codes": "^1.1.0",
-    "typedoc": "^0.16.10"
+    "locale-codes": "^1.1.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.8",
@@ -47,9 +68,13 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^25.2.0",
     "ts-loader": "^6.2.1",
+    "typedoc": "^0.16.10",
     "typedoc-plugin-markdown": "^2.2.16",
     "typescript": "^3.7.5",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.11"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/browser-client",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Browser client for Speechly API",
   "private": true,
   "keywords": [

--- a/src/speechly/client.ts
+++ b/src/speechly/client.ts
@@ -62,7 +62,7 @@ export class Client {
     this.debug = options.debug ?? false
     this.microphone = new Microphone(options.sampleRate ?? DefaultSampleRate)
     this.websocket = new Websocket(
-      options.url,
+      options.url ?? defaultSpeechlyURL,
       options.appId,
       options.language,
       options.deviceId ?? uuidv4(),
@@ -394,6 +394,7 @@ export class Client {
   }
 }
 
+const defaultSpeechlyURL = 'wss://api.speechly.com/ws'
 const initialReconnectDelay = 1000
 const initialReconnectCount = 5
 

--- a/src/speechly/client.ts
+++ b/src/speechly/client.ts
@@ -78,7 +78,7 @@ export class Client {
    * Initializes the client, by initializing the microphone and establishing connection to the API.
    * @param cb - the callback which is invoked when the initialization is complete.
    */
-  initialize(cb: ErrorCallback): void {
+  initialize(cb: ErrorCallback = () => {}): void {
     if (this.state !== ClientState.Disconnected) {
       return cb(new Error('Cannot initialize client - client is not in Disconnected state'))
     }
@@ -141,7 +141,7 @@ export class Client {
    * Starts a new SLU context by sending a start context event to the API and unmuting the microphone.
    * @param cb - the callback which is invoked when the context start was acknowledged by the API.
    */
-  startContext(cb: ContextCallback): void {
+  startContext(cb: ContextCallback = () => {}): void {
     if (this.state !== ClientState.Connected) {
       return cb(Error('Cannot start context - client is not connected'))
     }
@@ -171,7 +171,7 @@ export class Client {
    * Stops current SLU context by sending a stop context event to the API and muting the microphone.
    * @param cb - the callback which is invoked when the context stop was acknowledged by the API.
    */
-  stopContext(cb: ContextCallback): void {
+  stopContext(cb: ContextCallback = () => {}): void {
     if (this.state !== ClientState.Recording) {
       return cb(new Error('Cannot stop context - client is not recording'))
     }

--- a/src/speechly/types.ts
+++ b/src/speechly/types.ts
@@ -16,7 +16,7 @@ export interface ClientOptions {
   /**
    * The URL of Speechly API endpoint.
    */
-  url: string
+  url?: string
 
   /**
    * The identifier of the device which is using the client.

--- a/src/websocket/client.ts
+++ b/src/websocket/client.ts
@@ -2,7 +2,7 @@ import { ContextCallback, ErrorCallback } from '../types'
 import { WebsocketClient, ResponseCallback, CloseCallback, WebsocketResponse, WebsocketResponseType } from './types'
 
 export class Websocket implements WebsocketClient {
-  private readonly url: URL
+  private readonly url: string
   private readonly appId: string
   private websocket?: WebSocket
 
@@ -19,8 +19,8 @@ export class Websocket implements WebsocketClient {
     this.onCloseCb = cb
   }
 
-  constructor(url: string, appId: string, language: string, deviceId: string, sampleRate: number) {
-    this.url = generateWsUrl(url, deviceId, language, sampleRate)
+  constructor(baseUrl: string, appId: string, language: string, deviceId: string, sampleRate: number) {
+    this.url = generateWsUrl(baseUrl, deviceId, language, sampleRate)
     this.appId = appId
   }
 
@@ -29,7 +29,7 @@ export class Websocket implements WebsocketClient {
       return cb(Error('Cannot initialize an already initialized websocket client'))
     }
 
-    initializeWebsocket(this.url.toJSON(), this.appId, (err, ws) => {
+    initializeWebsocket(this.url, this.appId, (err, ws) => {
       if (err !== undefined) {
         return cb(err)
       }
@@ -137,20 +137,13 @@ export class Websocket implements WebsocketClient {
 const StartEventJSON = JSON.stringify({ event: 'start' })
 const StopEventJSON = JSON.stringify({ event: 'stop' })
 
-function generateWsUrl(url: string, deviceId: string, languageCode: string, sampleRate: number): URL {
+function generateWsUrl(baseUrl: string, deviceId: string, languageCode: string, sampleRate: number): string {
   const params = new URLSearchParams()
   params.set('deviceId', deviceId)
   params.set('languageCode', languageCode)
   params.set('sampleRate', sampleRate.toString())
 
-  const [host, port] = url.split(':')
-  const wsUrl = new URL(`ws://${host}`)
-  if (port !== undefined) {
-    wsUrl.port = port
-  }
-  wsUrl.search = params.toString()
-
-  return wsUrl
+  return `${baseUrl}?${params.toString()}`
 }
 
 function initializeWebsocket(url: string, protocol: string, cb: (err?: Error, ws?: WebSocket) => void): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,9 +391,9 @@
   integrity sha512-SX8JNEVy6U5+56aQnQB8A2XK+WSF//b0kBa6KqxE48pcccqVuIu1ePAR/EWd1cQB6zWv26QIY5uv/++qm+Z3Mw==
 
 "@sinonjs/commons@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.0.tgz#f90ffc52a2e519f018b13b6c4da03cbff36ebed6"
-  integrity sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
+  integrity sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==
   dependencies:
     type-detect "4.0.8"
 
@@ -506,39 +506,39 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^2.19.2":
-  version "2.19.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.19.2.tgz#e279aaae5d5c1f2547b4cff99204e1250bc7a058"
-  integrity sha512-HX2qOq2GOV04HNrmKnTpSIpHjfl7iwdXe3u/Nvt+/cpmdvzYvY0NHSiTkYN257jHnq4OM/yo+OsFgati+7LqJA==
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.20.0.tgz#a522d0e1e4898f7c9c6a8e1ed3579b60867693fa"
+  integrity sha512-cimIdVDV3MakiGJqMXw51Xci6oEDEoPkvh8ggJe2IIzcc0fYqAxOXN6Vbeanahz6dLZq64W+40iUEc9g32FLDQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.19.2"
+    "@typescript-eslint/experimental-utils" "2.20.0"
     eslint-utils "^1.4.3"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.19.2", "@typescript-eslint/experimental-utils@^2.5.0":
-  version "2.19.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.2.tgz#4611d44cf0f0cb460c26aa7676fc0a787281e233"
-  integrity sha512-B88QuwT1wMJR750YvTJBNjMZwmiPpbmKYLm1yI7PCc3x0NariqPwqaPsoJRwU9DmUi0cd9dkhz1IqEnwfD+P1A==
+"@typescript-eslint/experimental-utils@2.20.0", "@typescript-eslint/experimental-utils@^2.5.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.20.0.tgz#3b6fa5a6b8885f126d5a4280e0d44f0f41e73e32"
+  integrity sha512-fEBy9xYrwG9hfBLFEwGW2lKwDRTmYzH3DwTmYbT+SMycmxAoPl0eGretnBFj/s+NfYBG63w/5c3lsvqqz5mYag==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.19.2"
+    "@typescript-eslint/typescript-estree" "2.20.0"
     eslint-scope "^5.0.0"
 
 "@typescript-eslint/parser@^2.0.0", "@typescript-eslint/parser@^2.19.2":
-  version "2.19.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.19.2.tgz#21f42c0694846367e7d6a907feb08ab2f89c0879"
-  integrity sha512-8uwnYGKqX9wWHGPGdLB9sk9+12sjcdqEEYKGgbS8A0IvYX59h01o8os5qXUHMq2na8vpDRaV0suTLM7S8wraTA==
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.20.0.tgz#608e5bb06ba98a415b64ace994c79ab20f9772a9"
+  integrity sha512-o8qsKaosLh2qhMZiHNtaHKTHyCHc3Triq6aMnwnWj7budm3xAY9owSZzV1uon5T9cWmJRJGzTFa90aex4m77Lw==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.19.2"
-    "@typescript-eslint/typescript-estree" "2.19.2"
+    "@typescript-eslint/experimental-utils" "2.20.0"
+    "@typescript-eslint/typescript-estree" "2.20.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.19.2":
-  version "2.19.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.19.2.tgz#67485b00172f400474d243c6c0be27581a579350"
-  integrity sha512-Xu/qa0MDk6upQWqE4Qy2X16Xg8Vi32tQS2PR0AvnT/ZYS4YGDvtn2MStOh5y8Zy2mg4NuL06KUHlvCh95j9C6Q==
+"@typescript-eslint/typescript-estree@2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.20.0.tgz#90a0f5598826b35b966ca83483b1a621b1a4d0c9"
+  integrity sha512-WlFk8QtI8pPaE7JGQGxU7nGcnk1ccKAJkhbVookv94ZcAef3m6oCE/jEDL6dGte3JcD7reKrA0o55XhBRiVT3A==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -1222,11 +1222,6 @@ callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-
-camelcase@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
-  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
@@ -3702,9 +3697,9 @@ make-dir@^3.0.0:
     semver "^6.0.0"
 
 make-error@1.x:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
-  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -5486,9 +5481,9 @@ tr46@^1.0.1:
     punycode "^2.1.0"
 
 ts-jest@^25.2.0:
-  version "25.2.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.2.0.tgz#dfd87c2b71ef4867f5a0a44f40cb9c67e02991ac"
-  integrity sha512-VaRdb0da46eorLfuHEFf0G3d+jeREcV+Wb/SvW71S4y9Oe8SHWU+m1WY/3RaMknrBsnvmVH0/rRjT8dkgeffNQ==
+  version "25.2.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.2.1.tgz#49bf05da26a8b7fbfbc36b4ae2fcdc2fef35c85d"
+  integrity sha512-TnntkEEjuXq/Gxpw7xToarmHbAafgCaAzOpnajnFC6jI7oo1trMzAHA04eWpc3MhV6+yvhE8uUBAmN+teRJh0A==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"
@@ -5499,7 +5494,7 @@ ts-jest@^25.2.0:
     mkdirp "0.x"
     resolve "1.x"
     semver "^5.5"
-    yargs-parser "10.x"
+    yargs-parser "^16.1.0"
 
 ts-loader@^6.2.1:
   version "6.2.1"
@@ -5611,9 +5606,9 @@ typescript@3.7.x, typescript@^3.7.5, typescript@~3.7.2:
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 uglify-js@^3.1.4:
-  version "3.7.7"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.7.tgz#21e52c7dccda80a53bf7cde69628a7e511aec9c9"
-  integrity sha512-FeSU+hi7ULYy6mn8PKio/tXsdSXN35lm4KgV2asx00kzrLU9Pi3oAslcJT70Jdj7PHX29gGUPOT6+lXGBbemhA==
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.8.0.tgz#f3541ae97b2f048d7e7e3aa4f39fd8a1f5d7a805"
+  integrity sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==
   dependencies:
     commander "~2.20.3"
     source-map "~0.6.1"
@@ -5992,13 +5987,6 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yargs-parser@10.x:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
-  dependencies:
-    camelcase "^4.1.0"
 
 yargs-parser@^13.1.0:
   version "13.1.1"


### PR DESCRIPTION
### What

Make WebSocket URL optional (default pointing towards `wss://api.speechly.com/ws`) and simplify WS URL building logic to `baseUrl / params` approach, instead of trying to utilise the URL API.

### Why

Most of the time (outside of testing) the client will use production Speechly API and simpler logic makes it easier to use TLS or non-TLS URLs.
