### PR TITLE
Fix indices rendering in the example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ export REACT_APP_APP_ID="your-app-id"
 export REACT_APP_LANGUAGE="your-app-language"
 
 # Runs the demo in the development mode.
-# Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+# Open http://localhost:3000 to view it in the browser.
 #
 # The page will reload if you make edits.
 # You will also see any lint errors in the console.

--- a/examples/public/index.html
+++ b/examples/public/index.html
@@ -21,12 +21,12 @@
       <p id="transcript-words"></p>
 
       <h3>Words</h3>
-      <ol id="transcript-list"></ol>
+      <ul id="transcript-list"></ol>
     </div>
 
     <div id="entities">
       <h3>Entities</h3>
-      <ol id="entities-list"></ol>
+      <ul id="entities-list"></ol>
     </div>
 
     <div id="intent">

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -101,7 +101,9 @@ window.onload = () => {
 
     const wordsDiv = document.getElementById('transcript-list')
     wordsDiv.innerHTML = words
-      .map(word => (word.isFinal ? `<li><b>${word.value}</b></li>` : `<li>${word.value}</li>`))
+      .map(word =>
+        word.isFinal ? `<li><b>${word.value} [${word.index}]</b></li>` : `<li>${word.value} [${word.index}]</li>`
+      )
       .join('')
   }
 
@@ -109,7 +111,7 @@ window.onload = () => {
     const entitiesDiv = document.getElementById('entities-list')
     entitiesDiv.innerHTML = entities
       .map(entity => {
-        const t = `${entity.type} - ${entity.value} [${entity.startPosition} - ${entity.endPosition}]`
+        const t = `${entity.type} - ${entity.value} [${entity.startPosition} - ${entity.endPosition})`
         if (entity.isFinal) {
           return `<li><b>${t}</b></li>`
         }


### PR DESCRIPTION
### What

Fix indices rendering in the example, by switching to unordered lists for words and entities and indicating the entity range type (includes start index, but excludes end index).

### Why

Since the indices in the response are not guaranteed to be monotonically increasing and / or starting from 1, we should not rely on ordered lists to properly show those indices.
