### PR TITLE
Revert "Finalise last segment when context is stopped (#19)"

### DIFF
--- a/src/speechly/client.ts
+++ b/src/speechly/client.ts
@@ -216,7 +216,7 @@ export class Client {
 
       this.setState(ClientState.Recording)
       this.microphone.unmute()
-      this.activeContexts.set(ctxId, new SegmentState(ctxId, 0))
+      this.activeContexts.set(ctxId, new SegmentState(ctxId, 1))
 
       return cb(undefined, contextId)
     })
@@ -243,17 +243,11 @@ export class Client {
 
       const ctxId = contextId as string
 
-      // Finalise current segment if it has not been finalised yet.
-      const segmentState = this.activeContexts.get(ctxId)
-      if (segmentState?.isFinalized === false) {
-        this.segmentChangeCb(segmentState.finalize().toSegment())
-      }
-
+      this.setState(ClientState.Connected)
       if (!this.activeContexts.delete(ctxId)) {
         console.warn('[SpeechlyClient]', 'Attempted to remove non-existent context', ctxId)
       }
 
-      this.setState(ClientState.Connected)
       return cb()
     })
   }
@@ -332,15 +326,8 @@ export class Client {
     let { data } = response
 
     let segmentState = this.activeContexts.get(audio_context)
-
-    // eslint-disable-next-line @typescript-eslint/camelcase
-    if (segmentState === undefined || segmentState.id !== segment_id) {
-      console.warn(
-        '[SpeechlyClient]',
-        'Received response for non-existent context / segment ID',
-        audio_context,
-        segment_id
-      )
+    if (segmentState === undefined) {
+      console.warn('[SpeechlyClient]', 'Received response for non-existent context', audio_context)
       return
     }
 


### PR DESCRIPTION
This reverts commit a9a80a5ece7fdeb2ad7006f95498336737fcd3fb.

### What

Revert the finalisation of current segment upon receiving "context stopped" event.

### Why

The logic was causing some segment updates to be dropped, leading to bad experience.

