### PR TITLE
Improve resampling performance in Safari browsers

### DIFF
--- a/docs/interfaces/_index_d_.apiclient.md
+++ b/docs/interfaces/_index_d_.apiclient.md
@@ -104,7 +104,7 @@ ___
 
 ###  sendAudio
 
-▸ **sendAudio**(`audioChunk`: ArrayBuffer): *Error | void*
+▸ **sendAudio**(`audioChunk`: Int16Array): *Error | void*
 
 Defined in index.d.ts:59
 
@@ -115,7 +115,7 @@ If there is no active context (no successful previous calls to `startContext`), 
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`audioChunk` | ArrayBuffer | audio chunk to send.  |
+`audioChunk` | Int16Array | audio chunk to send.  |
 
 **Returns:** *Error | void*
 

--- a/docs/modules/_index_d_.md
+++ b/docs/modules/_index_d_.md
@@ -72,13 +72,13 @@ A callback that receives an ArrayBuffer representing a frame of audio.
 
 #### Type declaration:
 
-▸ (`audioBuffer`: ArrayBuffer): *void*
+▸ (`audioBuffer`: Int16Array): *void*
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`audioBuffer` | ArrayBuffer |
+`audioBuffer` | Int16Array |
 
 ___
 

--- a/etc/browser-client.api.md
+++ b/etc/browser-client.api.md
@@ -10,13 +10,13 @@ export interface APIClient {
     initialize(deviceID: string, cb: ErrorCallback): void;
     onClose(cb: CloseCallback): void;
     onResponse(cb: ResponseCallback): void;
-    sendAudio(audioChunk: ArrayBuffer): Error | void;
+    sendAudio(audioChunk: Int16Array): Error | void;
     startContext(cb: ContextCallback): void;
     stopContext(cb: ContextCallback): void;
 }
 
 // @public
-export type AudioCallback = (audioBuffer: ArrayBuffer) => void;
+export type AudioCallback = (audioBuffer: Int16Array) => void;
 
 // @public
 export class Client {

--- a/src/microphone/browser_microphone.ts
+++ b/src/microphone/browser_microphone.ts
@@ -1,18 +1,13 @@
 import { ErrorCallback } from '../types'
 import { AudioCallback, Microphone } from './types'
 import { AudioProcessor, BrowserAudioProcessor } from './browser_audio_processor'
-import { float32ToInt16, AudioFilter, newSampler } from './sampler'
 
 export class BrowserMicrophone implements Microphone {
   private readonly audioProcessor: AudioProcessor
-  private readonly downsampler: AudioFilter
-
-  private isMuted: boolean = false
   private onAudioCb: AudioCallback = () => {}
 
-  constructor(sampleRate: number, audioProcessor?: AudioProcessor, sampler?: AudioFilter) {
+  constructor(sampleRate: number, audioProcessor?: AudioProcessor) {
     this.audioProcessor = audioProcessor ?? new BrowserAudioProcessor(sampleRate, this.handleAudio)
-    this.downsampler = sampler ?? newSampler(this.audioProcessor.sampleRate, sampleRate)
   }
 
   onAudio(cb: AudioCallback): void {
@@ -36,20 +31,14 @@ export class BrowserMicrophone implements Microphone {
   }
 
   mute(): void {
-    this.isMuted = true
     this.audioProcessor.mute()
   }
 
   unmute(): void {
-    this.isMuted = false
     this.audioProcessor.unmute()
   }
 
-  private readonly handleAudio = (audioBuffer: Float32Array): void => {
-    if (this.isMuted) {
-      return
-    }
-
-    this.onAudioCb(float32ToInt16(this.downsampler.call(audioBuffer)))
+  private readonly handleAudio = (audioBuffer: Int16Array): void => {
+    this.onAudioCb(audioBuffer)
   }
 }

--- a/src/microphone/sampler.ts
+++ b/src/microphone/sampler.ts
@@ -1,13 +1,28 @@
+const emptyBuffer = new Float32Array(0)
+
 export interface AudioFilter {
-  call(input: Float32Array): Float32Array
+  readonly resampleRatio: number
+  call(input: Float32Array): Int16Array
+}
+
+export function newSampler(sourceSampleRate: number, targetSampleRate: number): AudioFilter {
+  if (sourceSampleRate === targetSampleRate) {
+    return new BypassSampler()
+  } else if (sourceSampleRate > targetSampleRate) {
+    return new DownSampler(sourceSampleRate, targetSampleRate, generateFilter(sourceSampleRate, targetSampleRate, 127))
+  } else {
+    throw Error('Upsampling is not supported!')
+  }
 }
 
 /**
  * BypassSampler is a re-sampler that simply returns the passed buffer without performing any sampling.
  */
 export class BypassSampler implements AudioFilter {
-  call(input: Float32Array): Float32Array {
-    return input
+  readonly resampleRatio = 1
+
+  call(input: Float32Array): Int16Array {
+    return float32ToInt16(input)
   }
 }
 
@@ -15,78 +30,68 @@ export class BypassSampler implements AudioFilter {
  * DownSampler is a re-sampler that performs downsampling on the passed audio buffer.
  */
 export class DownSampler implements AudioFilter {
+  readonly resampleRatio: number
+  private readonly filter: Float32Array
   private buffer: Float32Array
-  private readonly resampleRatio: number
-  private readonly filter: number[]
 
-  constructor(sourceSampleRate: number, targetSampleRate: number, filter: number[]) {
-    this.buffer = new Float32Array(0)
+  constructor(sourceSampleRate: number, targetSampleRate: number, filter: Float32Array) {
+    this.buffer = emptyBuffer
     this.resampleRatio = sourceSampleRate / targetSampleRate
     this.filter = filter
   }
 
-  call(input: Float32Array): Float32Array {
+  call(input: Float32Array): Int16Array {
     const inputBuffer = new Float32Array(this.buffer.length + input.length)
     inputBuffer.set(this.buffer, 0)
     inputBuffer.set(input, this.buffer.length)
 
     const outputLength = Math.ceil((inputBuffer.length - this.filter.length) / this.resampleRatio)
-    const outputBuffer = new Float32Array(outputLength)
+    const outputBuffer = new Int16Array(outputLength)
 
     for (let i = 0; i < outputLength; i++) {
       const offset = Math.round(this.resampleRatio * i)
+      let val = 0.0
 
       for (let j = 0; j < this.filter.length; j++) {
-        outputBuffer[i] += inputBuffer[offset + j] * this.filter[j]
+        val += inputBuffer[offset + j] * this.filter[j]
       }
+
+      outputBuffer[i] = val * (val < 0 ? 0x8000 : 0x7fff)
     }
 
     const remainingOffset = Math.round(this.resampleRatio * outputLength)
     if (remainingOffset < inputBuffer.length) {
-      this.buffer = inputBuffer.slice(remainingOffset)
+      this.buffer = inputBuffer.subarray(remainingOffset)
     } else {
-      this.buffer = this.buffer.slice(0, 0)
+      this.buffer = emptyBuffer
     }
 
     return outputBuffer
   }
 }
 
-export function newSampler(sourceSampleRate: number, targetSampleRate: number): AudioFilter {
-  if (sourceSampleRate === targetSampleRate) {
-    return new BypassSampler()
-  } else if (sourceSampleRate > targetSampleRate) {
-    return new DownSampler(
-      sourceSampleRate,
-      targetSampleRate,
-      generateFilter(sourceSampleRate, targetSampleRate / 2, 23)
-    )
-  } else {
-    throw Error('Upsampling is not supported!')
-  }
-}
+function float32ToInt16(buffer: Float32Array): Int16Array {
+  const buf = new Int16Array(buffer.length)
 
-export function float32ToInt16(buffer: Float32Array): ArrayBuffer {
-  let l = buffer.length
-  const buf = new Int16Array(l)
-
-  while (l-- > 0) {
+  for (let l = 0; l < buffer.length; l++) {
     buf[l] = buffer[l] * (buffer[l] < 0 ? 0x8000 : 0x7fff)
   }
 
-  return buf.buffer
+  return buf
 }
 
-function generateFilter(sourceSampleRate: number, targetSampleRate: number, length: number): number[] {
+function generateFilter(sourceSampleRate: number, targetSampleRate: number, length: number): Float32Array {
   if (length % 2 === 0) {
     throw Error('Filter length must be odd')
   }
 
-  const filter = new Array(length)
+  const cutoff = targetSampleRate / 2
+  const filter = new Float32Array(length)
   let sum = 0
 
   for (let i = 0; i < length; i++) {
-    const x = sinc(((2 * targetSampleRate) / sourceSampleRate) * (i - (length - 1) / 2))
+    const x = sinc(((2 * cutoff) / sourceSampleRate) * (i - (length - 1) / 2))
+
     sum += x
     filter[i] = x
   }

--- a/src/microphone/types.ts
+++ b/src/microphone/types.ts
@@ -34,7 +34,7 @@ export const ErrNoAudioConsent = new Error('Microphone consent is no given')
  * A callback that receives an ArrayBuffer representing a frame of audio.
  * @public
  */
-export type AudioCallback = (audioBuffer: ArrayBuffer) => void
+export type AudioCallback = (audioBuffer: Int16Array) => void
 
 /**
  * The interface for a microphone.

--- a/src/speechly/client.ts
+++ b/src/speechly/client.ts
@@ -445,7 +445,7 @@ export class Client {
     }, this.nextReconnectDelay)
   }
 
-  private readonly handleMicrophoneAudio = (audioChunk: ArrayBuffer): void => {
+  private readonly handleMicrophoneAudio = (audioChunk: Int16Array): void => {
     if (this.state !== ClientState.Recording) {
       return
     }

--- a/src/websocket/types.ts
+++ b/src/websocket/types.ts
@@ -219,5 +219,5 @@ export interface APIClient {
    *
    * @param audioChunk - audio chunk to send.
    */
-  sendAudio(audioChunk: ArrayBuffer): Error | void
+  sendAudio(audioChunk: Int16Array): Error | void
 }

--- a/src/websocket/websocket_client.ts
+++ b/src/websocket/websocket_client.ts
@@ -89,7 +89,7 @@ export class WebsocketClient implements APIClient {
     ws.send(StopEventJSON)
   }
 
-  sendAudio(audioChunk: ArrayBuffer): Error | void {
+  sendAudio(audioChunk: Int16Array): Error | void {
     if (!this.isOpen()) {
       return Error('Cannot send data through inactive websocket')
     }


### PR DESCRIPTION
### What

Improve resampling performance in Safari browsers with the following:

* Fix an issue in the lowpass filter generator, which was using wrong cutoff value
* Add custom buffer size value for WebKit browser (practically only means Safari) based on resample ratio
* Moved quantisation into the same loop as resampling

### Why

To achieve good audio quality in Safari browsers. Previously the audio quality was suffering from distortions, with the fixes the quality should be almost 100%. There still are occasional small distortions, but in general it's much better.

The quality issue seems to be caused by bad audio capture code in the engine itself, which seems to be performing very badly with default buffer size and in general is very sensitive to latency, hence the requirements to improve resampling / quantisation.
