### PR TITLE
Update default API URL

### DIFF
--- a/src/speechly/client.ts
+++ b/src/speechly/client.ts
@@ -41,7 +41,7 @@ import AsyncRetry from 'async-retry'
 
 const deviceIdStorageKey = 'speechly-device-id'
 const authTokenKey = 'speechly-auth-token'
-const defaultApiUrl = 'wss://api.speechly.com/ws'
+const defaultApiUrl = 'wss://api.speechly.com/ws/v1'
 const defaultLoginUrl = 'https://api.speechly.com/login'
 
 /**


### PR DESCRIPTION
### What

Update default API URL, since it's been changed.

### Why

To make sure that the client uses correct endpoint address.

