### PR TITLE
Fix/log segment string representation

### DIFF
--- a/docs/classes/_index_d_.client.md
+++ b/docs/classes/_index_d_.client.md
@@ -30,6 +30,7 @@ and dispatching them, as well as providing a high-level API for interacting with
 * [onTranscript](_index_d_.client.md#ontranscript)
 * [startContext](_index_d_.client.md#startcontext)
 * [stopContext](_index_d_.client.md#stopcontext)
+* [switchContext](_index_d_.client.md#switchcontext)
 
 ## Constructors
 
@@ -37,7 +38,7 @@ and dispatching them, as well as providing a high-level API for interacting with
 
 \+ **new Client**(`options`: [ClientOptions](../interfaces/_index_d_.clientoptions.md)): *[Client](_index_d_.client.md)*
 
-Defined in index.d.ts:91
+Defined in index.d.ts:107
 
 **Parameters:**
 
@@ -53,7 +54,7 @@ Name | Type |
 
 ▸ **close**(): *Promise‹void›*
 
-Defined in index.d.ts:106
+Defined in index.d.ts:126
 
 Closes the client by closing the API connection and disabling the microphone.
 
@@ -65,7 +66,7 @@ ___
 
 ▸ **initialize**(): *Promise‹void›*
 
-Defined in index.d.ts:102
+Defined in index.d.ts:122
 
 Initializes the client, by initializing the microphone and establishing connection to the API.
 
@@ -83,7 +84,7 @@ ___
 
 ▸ **onEntity**(`cb`: [EntityCallback](../modules/_index_d_.md#entitycallback)): *void*
 
-Defined in index.d.ts:145
+Defined in index.d.ts:174
 
 Adds a listener for entity responses from the API.
 
@@ -101,7 +102,7 @@ ___
 
 ▸ **onIntent**(`cb`: [IntentCallback](../modules/_index_d_.md#intentcallback)): *void*
 
-Defined in index.d.ts:155
+Defined in index.d.ts:184
 
 Adds a listener for intent responses from the API.
 
@@ -119,7 +120,7 @@ ___
 
 ▸ **onSegmentChange**(`cb`: [SegmentChangeCallback](../modules/_index_d_.md#segmentchangecallback)): *void*
 
-Defined in index.d.ts:125
+Defined in index.d.ts:154
 
 Adds a listener for current segment change events.
 
@@ -137,7 +138,7 @@ ___
 
 ▸ **onStateChange**(`cb`: [StateChangeCallback](../modules/_index_d_.md#statechangecallback)): *void*
 
-Defined in index.d.ts:120
+Defined in index.d.ts:149
 
 Adds a listener for client state change events.
 
@@ -155,7 +156,7 @@ ___
 
 ▸ **onTentativeEntities**(`cb`: [TentativeEntitiesCallback](../modules/_index_d_.md#tentativeentitiescallback)): *void*
 
-Defined in index.d.ts:140
+Defined in index.d.ts:169
 
 Adds a listener for tentative entities responses from the API.
 
@@ -173,7 +174,7 @@ ___
 
 ▸ **onTentativeIntent**(`cb`: [IntentCallback](../modules/_index_d_.md#intentcallback)): *void*
 
-Defined in index.d.ts:150
+Defined in index.d.ts:179
 
 Adds a listener for tentative intent responses from the API.
 
@@ -191,7 +192,7 @@ ___
 
 ▸ **onTentativeTranscript**(`cb`: [TentativeTranscriptCallback](../modules/_index_d_.md#tentativetranscriptcallback)): *void*
 
-Defined in index.d.ts:130
+Defined in index.d.ts:159
 
 Adds a listener for tentative transcript responses from the API.
 
@@ -209,7 +210,7 @@ ___
 
 ▸ **onTranscript**(`cb`: [TranscriptCallback](../modules/_index_d_.md#transcriptcallback)): *void*
 
-Defined in index.d.ts:135
+Defined in index.d.ts:164
 
 Adds a listener for transcript responses from the API.
 
@@ -225,11 +226,17 @@ ___
 
 ###  startContext
 
-▸ **startContext**(): *Promise‹string›*
+▸ **startContext**(`appId?`: undefined | string): *Promise‹string›*
 
-Defined in index.d.ts:111
+Defined in index.d.ts:137
 
 Starts a new SLU context by sending a start context event to the API and unmuting the microphone.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`appId?` | undefined &#124; string |
 
 **Returns:** *Promise‹string›*
 
@@ -239,8 +246,28 @@ ___
 
 ▸ **stopContext**(): *Promise‹string›*
 
-Defined in index.d.ts:115
+Defined in index.d.ts:143
 
-Stops current SLU context by sending a stop context event to the API and muting the microphone.
+Stops current SLU context by sending a stop context event to the API and muting the microphone
+delayed by contextStopDelay = 250 ms
 
 **Returns:** *Promise‹string›*
+
+___
+
+###  switchContext
+
+▸ **switchContext**(`appId`: string): *Promise‹void›*
+
+Defined in index.d.ts:132
+
+Stops current context and immediately starts a new SLU context
+by sending a start context event to the API and unmuting the microphone.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`appId` | string | unique identifier of an app in the dashboard.  |
+
+**Returns:** *Promise‹void›*

--- a/docs/enums/_index_d_.clientstate.md
+++ b/docs/enums/_index_d_.clientstate.md
@@ -29,7 +29,7 @@ to react to non-recoverable states.
 
 • **Connected**: = 6
 
-Defined in index.d.ts:225
+Defined in index.d.ts:260
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **Connecting**: = 5
 
-Defined in index.d.ts:224
+Defined in index.d.ts:259
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • **Disconnected**: = 3
 
-Defined in index.d.ts:222
+Defined in index.d.ts:257
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • **Disconnecting**: = 4
 
-Defined in index.d.ts:223
+Defined in index.d.ts:258
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • **Failed**: = 0
 
-Defined in index.d.ts:219
+Defined in index.d.ts:254
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **NoAudioConsent**: = 2
 
-Defined in index.d.ts:221
+Defined in index.d.ts:256
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **NoBrowserSupport**: = 1
 
-Defined in index.d.ts:220
+Defined in index.d.ts:255
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • **Recording**: = 9
 
-Defined in index.d.ts:228
+Defined in index.d.ts:263
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • **Starting**: = 7
 
-Defined in index.d.ts:226
+Defined in index.d.ts:261
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 • **Stopping**: = 8
 
-Defined in index.d.ts:227
+Defined in index.d.ts:262

--- a/docs/enums/_index_d_.websocketresponsetype.md
+++ b/docs/enums/_index_d_.websocketresponsetype.md
@@ -10,7 +10,9 @@ Known WebSocket response types.
 
 * [Entity](_index_d_.websocketresponsetype.md#entity)
 * [Intent](_index_d_.websocketresponsetype.md#intent)
+* [Opened](_index_d_.websocketresponsetype.md#opened)
 * [SegmentEnd](_index_d_.websocketresponsetype.md#segmentend)
+* [SourceSampleRateSetSuccess](_index_d_.websocketresponsetype.md#sourcesampleratesetsuccess)
 * [Started](_index_d_.websocketresponsetype.md#started)
 * [Stopped](_index_d_.websocketresponsetype.md#stopped)
 * [TentativeEntities](_index_d_.websocketresponsetype.md#tentativeentities)
@@ -24,7 +26,7 @@ Known WebSocket response types.
 
 • **Entity**: = "entity"
 
-Defined in index.d.ts:609
+Defined in index.d.ts:625
 
 ___
 
@@ -32,7 +34,15 @@ ___
 
 • **Intent**: = "intent"
 
-Defined in index.d.ts:610
+Defined in index.d.ts:626
+
+___
+
+###  Opened
+
+• **Opened**: = "WEBSOCKET_OPEN"
+
+Defined in index.d.ts:619
 
 ___
 
@@ -40,7 +50,15 @@ ___
 
 • **SegmentEnd**: = "segment_end"
 
-Defined in index.d.ts:607
+Defined in index.d.ts:623
+
+___
+
+###  SourceSampleRateSetSuccess
+
+• **SourceSampleRateSetSuccess**: = "SOURSE_SAMPLE_RATE_SET_SUCCESS"
+
+Defined in index.d.ts:620
 
 ___
 
@@ -48,7 +66,7 @@ ___
 
 • **Started**: = "started"
 
-Defined in index.d.ts:605
+Defined in index.d.ts:621
 
 ___
 
@@ -56,7 +74,7 @@ ___
 
 • **Stopped**: = "stopped"
 
-Defined in index.d.ts:606
+Defined in index.d.ts:622
 
 ___
 
@@ -64,7 +82,7 @@ ___
 
 • **TentativeEntities**: = "tentative_entities"
 
-Defined in index.d.ts:612
+Defined in index.d.ts:628
 
 ___
 
@@ -72,7 +90,7 @@ ___
 
 • **TentativeIntent**: = "tentative_intent"
 
-Defined in index.d.ts:613
+Defined in index.d.ts:629
 
 ___
 
@@ -80,7 +98,7 @@ ___
 
 • **TentativeTranscript**: = "tentative_transcript"
 
-Defined in index.d.ts:611
+Defined in index.d.ts:627
 
 ___
 
@@ -88,4 +106,4 @@ ___
 
 • **Transcript**: = "transcript"
 
-Defined in index.d.ts:608
+Defined in index.d.ts:624

--- a/docs/interfaces/_index_d_.apiclient.md
+++ b/docs/interfaces/_index_d_.apiclient.md
@@ -16,9 +16,11 @@ The interface for a client for Speechly SLU WebSocket API.
 * [initialize](_index_d_.apiclient.md#initialize)
 * [onClose](_index_d_.apiclient.md#onclose)
 * [onResponse](_index_d_.apiclient.md#onresponse)
+* [postMessage](_index_d_.apiclient.md#postmessage)
 * [sendAudio](_index_d_.apiclient.md#sendaudio)
 * [startContext](_index_d_.apiclient.md#startcontext)
 * [stopContext](_index_d_.apiclient.md#stopcontext)
+* [switchContext](_index_d_.apiclient.md#switchcontext)
 
 ## Methods
 
@@ -26,7 +28,7 @@ The interface for a client for Speechly SLU WebSocket API.
 
 ▸ **close**(): *Promise‹void›*
 
-Defined in index.d.ts:40
+Defined in index.d.ts:34
 
 Closes the client.
 
@@ -39,27 +41,22 @@ ___
 
 ###  initialize
 
-▸ **initialize**(`appId`: string, `deviceId`: string, `token?`: undefined | string): *Promise‹string›*
+▸ **initialize**(`sourceSampleRate`: number): *Promise‹void›*
 
-Defined in index.d.ts:33
+Defined in index.d.ts:27
 
 Initialises the client.
 
-This should prepare websocket to be used (i.e. establish connection to the API).
+This should prepare websocket to be used (set source sample rate).
 This method will be called by the Client as part of the initialisation process.
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`appId` | string | app ID to use when connecting to the API. |
-`deviceId` | string | device ID to use when connecting to the API. |
-`token?` | undefined &#124; string | login token in JWT format, which was e.g. cached from previous session.                If the token is not provided or is invalid, a new token will be fetched instead.  |
+`sourceSampleRate` | number | sample rate of audio source.  |
 
-**Returns:** *Promise‹string›*
-
-- the token that was used to establish connection to the API, so that it can be cached for later.
-           If the provided token was used, it will be returned instead.
+**Returns:** *Promise‹void›*
 
 ___
 
@@ -99,11 +96,29 @@ Name | Type | Description |
 
 ___
 
+###  postMessage
+
+▸ **postMessage**(`message`: Object): *void*
+
+Defined in index.d.ts:62
+
+Sends message to the Worker.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`message` | Object | message to send.  |
+
+**Returns:** *void*
+
+___
+
 ###  sendAudio
 
-▸ **sendAudio**(`audioChunk`: Int16Array): *Error | void*
+▸ **sendAudio**(`audioChunk`: Float32Array): *void*
 
-Defined in index.d.ts:57
+Defined in index.d.ts:56
 
 Sends audio to the API.
 If there is no active context (no successful previous calls to `startContext`), this must fail.
@@ -112,20 +127,26 @@ If there is no active context (no successful previous calls to `startContext`), 
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`audioChunk` | Int16Array | audio chunk to send.  |
+`audioChunk` | Float32Array | audio chunk to send.  |
 
-**Returns:** *Error | void*
+**Returns:** *void*
 
 ___
 
 ###  startContext
 
-▸ **startContext**(): *Promise‹string›*
+▸ **startContext**(`appId?`: undefined | string): *Promise‹string›*
 
-Defined in index.d.ts:45
+Defined in index.d.ts:39
 
 Starts a new audio context by sending the start event to the API.
 The promise returned should resolve or reject after the API has responded with confirmation or an error has occured.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`appId?` | undefined &#124; string |
 
 **Returns:** *Promise‹string›*
 
@@ -135,9 +156,28 @@ ___
 
 ▸ **stopContext**(): *Promise‹string›*
 
-Defined in index.d.ts:50
+Defined in index.d.ts:44
 
 Stops an audio context by sending the stop event to the API.
 The promise returned should resolve or reject after the API has responded with confirmation or an error has occured.
+
+**Returns:** *Promise‹string›*
+
+___
+
+###  switchContext
+
+▸ **switchContext**(`appId`: string): *Promise‹string›*
+
+Defined in index.d.ts:49
+
+Stops current context and immediately starts a new SLU context
+by sending a start context event to the API and unmuting the microphone.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`appId` | string |
 
 **Returns:** *Promise‹string›*

--- a/docs/interfaces/_index_d_.clientoptions.md
+++ b/docs/interfaces/_index_d_.clientoptions.md
@@ -14,11 +14,13 @@ The options which can be used to configure the client.
 
 * [apiClient](_index_d_.clientoptions.md#optional-apiclient)
 * [apiUrl](_index_d_.clientoptions.md#optional-apiurl)
-* [appId](_index_d_.clientoptions.md#appid)
+* [appId](_index_d_.clientoptions.md#optional-appid)
 * [debug](_index_d_.clientoptions.md#optional-debug)
-* [language](_index_d_.clientoptions.md#language)
+* [language](_index_d_.clientoptions.md#optional-language)
+* [logSegments](_index_d_.clientoptions.md#optional-logsegments)
 * [loginUrl](_index_d_.clientoptions.md#optional-loginurl)
 * [microphone](_index_d_.clientoptions.md#optional-microphone)
+* [projectId](_index_d_.clientoptions.md#optional-projectid)
 * [sampleRate](_index_d_.clientoptions.md#optional-samplerate)
 * [storage](_index_d_.clientoptions.md#optional-storage)
 
@@ -28,7 +30,7 @@ The options which can be used to configure the client.
 
 • **apiClient**? : *[APIClient](_index_d_.apiclient.md)*
 
-Defined in index.d.ts:202
+Defined in index.d.ts:237
 
 Custom API client implementation.
 If not provided, an implementation based on Speechly SLU WebSocket API is used.
@@ -39,17 +41,17 @@ ___
 
 • **apiUrl**? : *undefined | string*
 
-Defined in index.d.ts:184
+Defined in index.d.ts:215
 
 The URL of Speechly SLU API endpoint.
 
 ___
 
-###  appId
+### `Optional` appId
 
-• **appId**: *string*
+• **appId**? : *undefined | string*
 
-Defined in index.d.ts:172
+Defined in index.d.ts:199
 
 The unique identifier of an app in the dashboard.
 
@@ -59,19 +61,29 @@ ___
 
 • **debug**? : *undefined | false | true*
 
-Defined in index.d.ts:192
+Defined in index.d.ts:223
 
 Whether to output debug statements to the console.
 
 ___
 
-###  `Optional` language
+### `Optional` language
 
-• **language**?: *undefined | string*
+• **language**? : *undefined | string*
 
-Defined in index.d.ts:176
+Defined in index.d.ts:207
 
 The language which is used by the app.
+
+___
+
+### `Optional` logSegments
+
+• **logSegments**? : *undefined | false | true*
+
+Defined in index.d.ts:227
+
+Whether to output updated segments to the console.
 
 ___
 
@@ -79,7 +91,7 @@ ___
 
 • **loginUrl**? : *undefined | string*
 
-Defined in index.d.ts:180
+Defined in index.d.ts:211
 
 The URL of Speechly login endpoint.
 
@@ -89,10 +101,20 @@ ___
 
 • **microphone**? : *[Microphone](_index_d_.microphone.md)*
 
-Defined in index.d.ts:197
+Defined in index.d.ts:232
 
 Custom microphone implementation.
 If not provided, an implementation based on getUserMedia and Web Audio API is used.
+
+___
+
+### `Optional` projectId
+
+• **projectId**? : *undefined | string*
+
+Defined in index.d.ts:203
+
+The unique identifier of a project in the dashboard.
 
 ___
 
@@ -100,7 +122,7 @@ ___
 
 • **sampleRate**? : *undefined | number*
 
-Defined in index.d.ts:188
+Defined in index.d.ts:219
 
 The sample rate of the audio to use.
 
@@ -110,7 +132,7 @@ ___
 
 • **storage**? : *Storage_2*
 
-Defined in index.d.ts:207
+Defined in index.d.ts:242
 
 Custom storage implementation.
 If not provided, browser's LocalStorage API is used.

--- a/docs/interfaces/_index_d_.entity.md
+++ b/docs/interfaces/_index_d_.entity.md
@@ -24,7 +24,7 @@ A single entity detected by the SLU API.
 
 • **endPosition**: *number*
 
-Defined in index.d.ts:263
+Defined in index.d.ts:298
 
 The index of the last word that contains this entity.
 
@@ -34,7 +34,7 @@ ___
 
 • **isFinal**: *boolean*
 
-Defined in index.d.ts:267
+Defined in index.d.ts:302
 
 Whether the entity was detected as final.
 
@@ -44,7 +44,7 @@ ___
 
 • **startPosition**: *number*
 
-Defined in index.d.ts:259
+Defined in index.d.ts:294
 
 The index of the first word that contains this entity.
 
@@ -54,7 +54,7 @@ ___
 
 • **type**: *string*
 
-Defined in index.d.ts:251
+Defined in index.d.ts:286
 
 The type specified by the developer in the NLU rules in the dashboard (e.g. restaurant_type).
 
@@ -64,6 +64,6 @@ ___
 
 • **value**: *string*
 
-Defined in index.d.ts:255
+Defined in index.d.ts:290
 
 The value of the entity (e.g. Papa Joe's).

--- a/docs/interfaces/_index_d_.entityresponse.md
+++ b/docs/interfaces/_index_d_.entityresponse.md
@@ -23,7 +23,7 @@ Entity response payload.
 
 • **end_position**: *number*
 
-Defined in index.d.ts:298
+Defined in index.d.ts:333
 
 End position of the entity in the segment. Correlates with TranscriptResponse indices.
 Exclusive.
@@ -34,7 +34,7 @@ ___
 
 • **entity**: *string*
 
-Defined in index.d.ts:284
+Defined in index.d.ts:319
 
 Entity type (e.g. restaurant, direction, room, device).
 
@@ -44,7 +44,7 @@ ___
 
 • **start_position**: *number*
 
-Defined in index.d.ts:293
+Defined in index.d.ts:328
 
 Start position of the entity in the segment. Correlates with TranscriptResponse indices.
 Inclusive.
@@ -55,6 +55,6 @@ ___
 
 • **value**: *string*
 
-Defined in index.d.ts:288
+Defined in index.d.ts:323
 
 Entity value (e.g. "sushi bar", "northwest", "living room", "kitchen lights").

--- a/docs/interfaces/_index_d_.intent.md
+++ b/docs/interfaces/_index_d_.intent.md
@@ -21,7 +21,7 @@ The intent detected by the SLU API.
 
 • **intent**: *string*
 
-Defined in index.d.ts:345
+Defined in index.d.ts:380
 
 The value of the intent.
 
@@ -31,6 +31,6 @@ ___
 
 • **isFinal**: *boolean*
 
-Defined in index.d.ts:349
+Defined in index.d.ts:384
 
 Whether the intent was detected as final.

--- a/docs/interfaces/_index_d_.intentresponse.md
+++ b/docs/interfaces/_index_d_.intentresponse.md
@@ -20,6 +20,6 @@ Intent response payload.
 
 • **intent**: *string*
 
-Defined in index.d.ts:366
+Defined in index.d.ts:401
 
 Intent type (e.g. "book", "find", "turn_on").

--- a/docs/interfaces/_index_d_.microphone.md
+++ b/docs/interfaces/_index_d_.microphone.md
@@ -15,7 +15,6 @@ The interface for a microphone.
 * [close](_index_d_.microphone.md#close)
 * [initialize](_index_d_.microphone.md#initialize)
 * [mute](_index_d_.microphone.md#mute)
-* [onAudio](_index_d_.microphone.md#onaudio)
 * [unmute](_index_d_.microphone.md#unmute)
 
 ## Methods
@@ -24,7 +23,7 @@ The interface for a microphone.
 
 ▸ **close**(): *Promise‹void›*
 
-Defined in index.d.ts:395
+Defined in index.d.ts:424
 
 Closes the microphone, tearing down all the infrastructure.
 
@@ -38,15 +37,22 @@ ___
 
 ###  initialize
 
-▸ **initialize**(): *Promise‹void›*
+▸ **initialize**(`audioContext`: AudioContext, `opts`: MediaStreamConstraints): *Promise‹void›*
 
-Defined in index.d.ts:387
+Defined in index.d.ts:416
 
 Initialises the microphone.
 
 This should prepare the microphone infrastructure for receiving audio chunks,
 but the microphone should remain muted after the call.
 This method will be called by the Client as part of client initialisation process.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`audioContext` | AudioContext |
+`opts` | MediaStreamConstraints |
 
 **Returns:** *Promise‹void›*
 
@@ -56,27 +62,9 @@ ___
 
 ▸ **mute**(): *void*
 
-Defined in index.d.ts:399
+Defined in index.d.ts:428
 
 Mutes the microphone. If the microphone is muted, the `onAudio` callbacks should not be called.
-
-**Returns:** *void*
-
-___
-
-###  onAudio
-
-▸ **onAudio**(`cb`: [AudioCallback](../modules/_index_d_.md#audiocallback)): *void*
-
-Defined in index.d.ts:379
-
-Registers the callback that is invoked whenever an audio chunk is emitted.
-
-**Parameters:**
-
-Name | Type | Description |
------- | ------ | ------ |
-`cb` | [AudioCallback](../modules/_index_d_.md#audiocallback) | the callback to invoke.  |
 
 **Returns:** *void*
 
@@ -86,7 +74,7 @@ ___
 
 ▸ **unmute**(): *void*
 
-Defined in index.d.ts:403
+Defined in index.d.ts:432
 
 Unmutes the microphone.
 

--- a/docs/interfaces/_index_d_.segment.md
+++ b/docs/interfaces/_index_d_.segment.md
@@ -25,7 +25,7 @@ The smallest component of SLU API, defined by an intent.
 
 • **contextId**: *string*
 
-Defined in index.d.ts:420
+Defined in index.d.ts:449
 
 The identifier of parent SLU context.
 
@@ -35,7 +35,7 @@ ___
 
 • **entities**: *[Entity](_index_d_.entity.md)[]*
 
-Defined in index.d.ts:440
+Defined in index.d.ts:469
 
 All entities which belong to the segment, not ordered.
 
@@ -45,7 +45,7 @@ ___
 
 • **id**: *number*
 
-Defined in index.d.ts:424
+Defined in index.d.ts:453
 
 The identifier of the segment within the parent context.
 
@@ -55,7 +55,7 @@ ___
 
 • **intent**: *[Intent](_index_d_.intent.md)*
 
-Defined in index.d.ts:432
+Defined in index.d.ts:461
 
 The intent of the segment.
 
@@ -65,7 +65,7 @@ ___
 
 • **isFinal**: *boolean*
 
-Defined in index.d.ts:428
+Defined in index.d.ts:457
 
 Whether the segment is final. A final segment is guaranteed to only contain final parts.
 
@@ -75,6 +75,6 @@ ___
 
 • **words**: *[Word](_index_d_.word.md)[]*
 
-Defined in index.d.ts:436
+Defined in index.d.ts:465
 
 All words which belong to the segment, ordered by their indices.

--- a/docs/interfaces/_index_d_.tentativeentitiesresponse.md
+++ b/docs/interfaces/_index_d_.tentativeentitiesresponse.md
@@ -20,6 +20,6 @@ Tenative entities response payload.
 
 • **entities**: *[EntityResponse](_index_d_.entityresponse.md)[]*
 
-Defined in index.d.ts:520
+Defined in index.d.ts:534
 
 Individual entities.

--- a/docs/interfaces/_index_d_.tentativetranscriptresponse.md
+++ b/docs/interfaces/_index_d_.tentativetranscriptresponse.md
@@ -21,7 +21,7 @@ Tentative transcript response payload.
 
 • **transcript**: *string*
 
-Defined in index.d.ts:537
+Defined in index.d.ts:551
 
 Transcript text, i.e. the full transcript of the audio to-date.
 
@@ -31,6 +31,6 @@ ___
 
 • **words**: *[TranscriptResponse](_index_d_.transcriptresponse.md)[]*
 
-Defined in index.d.ts:541
+Defined in index.d.ts:555
 
 Individual transcript words.

--- a/docs/interfaces/_index_d_.transcriptresponse.md
+++ b/docs/interfaces/_index_d_.transcriptresponse.md
@@ -23,7 +23,7 @@ Transcript response payload.
 
 • **end_timestamp**: *number*
 
-Defined in index.d.ts:570
+Defined in index.d.ts:584
 
 End timestamp of the transcript in the audio stream in milliseconds.
 
@@ -33,7 +33,7 @@ ___
 
 • **index**: *number*
 
-Defined in index.d.ts:562
+Defined in index.d.ts:576
 
 The index of the transcripted word in the segment.
 
@@ -43,7 +43,7 @@ ___
 
 • **start_timestamp**: *number*
 
-Defined in index.d.ts:566
+Defined in index.d.ts:580
 
 Start timestamp of the transcript in the audio stream in milliseconds.
 
@@ -53,6 +53,6 @@ ___
 
 • **word**: *string*
 
-Defined in index.d.ts:558
+Defined in index.d.ts:572
 
 Transcripted word.

--- a/docs/interfaces/_index_d_.websocketresponse.md
+++ b/docs/interfaces/_index_d_.websocketresponse.md
@@ -23,7 +23,7 @@ The interface for response returned by WebSocket client.
 
 • **audio_context**: *string*
 
-Defined in index.d.ts:585
+Defined in index.d.ts:599
 
 Audio context ID.
 
@@ -33,7 +33,7 @@ ___
 
 • **data**: *[TranscriptResponse](_index_d_.transcriptresponse.md) | [EntityResponse](_index_d_.entityresponse.md) | [IntentResponse](_index_d_.intentresponse.md) | [TentativeTranscriptResponse](_index_d_.tentativetranscriptresponse.md) | [TentativeEntitiesResponse](_index_d_.tentativeentitiesresponse.md)*
 
-Defined in index.d.ts:597
+Defined in index.d.ts:611
 
 Response payload.
 
@@ -47,7 +47,7 @@ ___
 
 • **segment_id**: *number*
 
-Defined in index.d.ts:589
+Defined in index.d.ts:603
 
 Segment ID.
 
@@ -57,6 +57,6 @@ ___
 
 • **type**: *[WebsocketResponseType](../enums/_index_d_.websocketresponsetype.md)*
 
-Defined in index.d.ts:581
+Defined in index.d.ts:595
 
 Response type.

--- a/docs/interfaces/_index_d_.word.md
+++ b/docs/interfaces/_index_d_.word.md
@@ -24,7 +24,7 @@ A single word detected by the SLU API.
 
 • **endTimestamp**: *number*
 
-Defined in index.d.ts:636
+Defined in index.d.ts:652
 
 End timestamp of the word within the audio of the context.
 
@@ -34,7 +34,7 @@ ___
 
 • **index**: *number*
 
-Defined in index.d.ts:628
+Defined in index.d.ts:644
 
 The index of the word within a segment.
 
@@ -44,7 +44,7 @@ ___
 
 • **isFinal**: *boolean*
 
-Defined in index.d.ts:640
+Defined in index.d.ts:656
 
 Whether the word was detected as final.
 
@@ -54,7 +54,7 @@ ___
 
 • **startTimestamp**: *number*
 
-Defined in index.d.ts:632
+Defined in index.d.ts:648
 
 Start timestamp of the word within the audio of the context.
 
@@ -64,6 +64,6 @@ ___
 
 • **value**: *string*
 
-Defined in index.d.ts:624
+Defined in index.d.ts:640
 
 The value of the word.

--- a/docs/modules/_index_d_.md
+++ b/docs/modules/_index_d_.md
@@ -72,7 +72,7 @@
 
 Ƭ **AudioCallback**: *function*
 
-Defined in index.d.ts:64
+Defined in index.d.ts:69
 
 A callback that receives an ArrayBuffer representing a frame of audio.
 
@@ -92,7 +92,7 @@ ___
 
 Ƭ **CloseCallback**: *function*
 
-Defined in index.d.ts:235
+Defined in index.d.ts:270
 
 A callback that is invoked whenever WebSocket connection is closed.
 
@@ -112,7 +112,7 @@ ___
 
 Ƭ **EntityCallback**: *function*
 
-Defined in index.d.ts:274
+Defined in index.d.ts:309
 
 A callback that is invoked whenever new entity is received from the API.
 
@@ -134,7 +134,7 @@ ___
 
 Ƭ **IntentCallback**: *function*
 
-Defined in index.d.ts:356
+Defined in index.d.ts:391
 
 A callback that is invoked whenever new intent (tentative or not) is received from the API.
 
@@ -156,7 +156,7 @@ ___
 
 Ƭ **ResponseCallback**: *function*
 
-Defined in index.d.ts:410
+Defined in index.d.ts:439
 
 A callback that is invoked whenever a response is received from Speechly SLU WebSocket API.
 
@@ -176,7 +176,7 @@ ___
 
 Ƭ **SegmentChangeCallback**: *function*
 
-Defined in index.d.ts:447
+Defined in index.d.ts:476
 
 A callback that is invoked whenever current {@link Segment | segment} changes.
 
@@ -196,7 +196,7 @@ ___
 
 Ƭ **StateChangeCallback**: *function*
 
-Defined in index.d.ts:453
+Defined in index.d.ts:482
 
 A callback that is invoked whenever the {@link ClientState | client state} changes.
 
@@ -216,7 +216,7 @@ ___
 
 Ƭ **TentativeEntitiesCallback**: *function*
 
-Defined in index.d.ts:510
+Defined in index.d.ts:524
 
 A callback that is invoked whenever new tentative entities are received from the API.
 
@@ -238,7 +238,7 @@ ___
 
 Ƭ **TentativeTranscriptCallback**: *function*
 
-Defined in index.d.ts:527
+Defined in index.d.ts:541
 
 A callback that is invoked whenever a new tentative transcript is received from the API.
 
@@ -261,7 +261,7 @@ ___
 
 Ƭ **TranscriptCallback**: *function*
 
-Defined in index.d.ts:548
+Defined in index.d.ts:562
 
 A callback that is invoked whenever a new transcript is received from the API.
 
@@ -283,7 +283,7 @@ Name | Type |
 
 • **DefaultSampleRate**: *16000* = 16000
 
-Defined in index.d.ts:241
+Defined in index.d.ts:276
 
 Default sample rate for microphone streams.
 
@@ -293,7 +293,7 @@ ___
 
 • **ErrAlreadyInitialized**: *Error*
 
-Defined in index.d.ts:305
+Defined in index.d.ts:340
 
 Error to be thrown when the initialize method of a Microphone instance is called more than once.
 
@@ -303,7 +303,7 @@ ___
 
 • **ErrDeviceNotSupported**: *Error*
 
-Defined in index.d.ts:311
+Defined in index.d.ts:346
 
 Error to be thrown when the device does not support the Microphone instance's target audio APIs.
 
@@ -313,7 +313,7 @@ ___
 
 • **ErrKeyNotFound**: *Error*
 
-Defined in index.d.ts:317
+Defined in index.d.ts:352
 
 Error to be thrown if requested key was not found in the storage.
 
@@ -323,7 +323,7 @@ ___
 
 • **ErrNoAudioConsent**: *Error*
 
-Defined in index.d.ts:323
+Defined in index.d.ts:358
 
 Error to be thrown when user did not give consent to the application to record audio.
 
@@ -333,7 +333,7 @@ ___
 
 • **ErrNoStorageSupport**: *Error*
 
-Defined in index.d.ts:329
+Defined in index.d.ts:364
 
 Error to be thrown if storage API is not supported by the device.
 
@@ -343,7 +343,7 @@ ___
 
 • **ErrNotInitialized**: *Error*
 
-Defined in index.d.ts:335
+Defined in index.d.ts:370
 
 Error to be thrown when the microphone was accessed before it was initialized.
 
@@ -353,7 +353,7 @@ Error to be thrown when the microphone was accessed before it was initialized.
 
 ▸ **stateToString**(`state`: [ClientState](../enums/_index_d_.clientstate.md)): *string*
 
-Defined in index.d.ts:460
+Defined in index.d.ts:489
 
 Converts client state value to a string, which could be useful for debugging or metrics.
 

--- a/etc/browser-client.api.md
+++ b/etc/browser-client.api.md
@@ -46,6 +46,7 @@ export interface ClientOptions {
     debug?: boolean;
     language?: string;
     loginUrl?: string;
+    logSegments?: boolean;
     microphone?: Microphone;
     projectId?: string;
     sampleRate?: number;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/browser-client",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Browser client for Speechly API",
   "private": true,
   "keywords": [

--- a/src/speechly/client.ts
+++ b/src/speechly/client.ts
@@ -59,6 +59,7 @@ declare global {
  */
 export class Client {
   private readonly debug: boolean
+  private readonly logSegments: boolean
   private readonly projectId?: string
   private readonly appId?: string
   private readonly storage: Storage
@@ -106,6 +107,7 @@ export class Client {
     }
 
     this.debug = options.debug ?? false
+    this.logSegments = options.logSegments ?? false
     this.loginUrl = options.loginUrl ?? defaultLoginUrl
     this.appId = options.appId ?? undefined
     this.projectId = options.projectId ?? undefined
@@ -492,6 +494,11 @@ export class Client {
 
     // Update current contexts.
     this.activeContexts.set(audio_context, context)
+
+    // Log segment to console
+    if (this.logSegments) {
+      console.info(segmentState.toString())
+    }
 
     // Fire segment change event.
     this.segmentChangeCb(segmentState.toSegment())

--- a/src/speechly/client.ts
+++ b/src/speechly/client.ts
@@ -48,7 +48,9 @@ const defaultLoginUrl = 'https://api.speechly.com/login'
 const defaultLanguage = 'en-US'
 
 declare global {
-  interface Window { SpeechlyClient: Client }
+  interface Window {
+    SpeechlyClient: Client
+  }
 }
 
 /**
@@ -120,12 +122,16 @@ export class Client {
 
     // 2. Fetch auth token. It doesn't matter if it's not present.
     if (storedToken == null || !validateToken(storedToken, this.projectId, this.appId, this.deviceId)) {
-      fetchToken(this.loginUrl, this.projectId, this.appId, this.deviceId).then((token) => {
-        this.authToken = token
-        // Cache the auth token in local storage for future use.
-        this.storage.set(authTokenKey, this.authToken)
-        this.connect(apiUrl)
-      }).catch(err => { throw err })
+      fetchToken(this.loginUrl, this.projectId, this.appId, this.deviceId)
+        .then(token => {
+          this.authToken = token
+          // Cache the auth token in local storage for future use.
+          this.storage.set(authTokenKey, this.authToken)
+          this.connect(apiUrl)
+        })
+        .catch(err => {
+          throw err
+        })
     } else {
       this.authToken = storedToken
       this.connect(apiUrl)
@@ -148,7 +154,7 @@ export class Client {
 
   /**
    * Esteblish websocket connection
-  */
+   */
   private connect(apiUrl: string): void {
     this.apiClient.postMessage({
       type: 'INIT',
@@ -331,17 +337,25 @@ export class Client {
 
     this.setState(ClientState.Stopping)
 
-    this.stoppedContextIdPromise = new Promise((resolve) => {
+    this.stoppedContextIdPromise = new Promise(resolve => {
       Promise.race([
-        new Promise((resolve) => setTimeout(resolve, this.contextStopDelay)), // timeout
-        new Promise((resolve) => { this.resolveStopContext = resolve }),
+        new Promise(resolve => setTimeout(resolve, this.contextStopDelay)), // timeout
+        new Promise(resolve => {
+          this.resolveStopContext = resolve
+        }),
       ])
         .then(() => {
           this._stopContext()
-            .then(id => { resolve(id) })
-            .catch(err => { throw err })
+            .then(id => {
+              resolve(id)
+            })
+            .catch(err => {
+              throw err
+            })
         })
-        .catch(err => { throw err })
+        .catch(err => {
+          throw err
+        })
     })
 
     const contextId: string = await this.stoppedContextIdPromise

--- a/src/speechly/segment.ts
+++ b/src/speechly/segment.ts
@@ -31,6 +31,15 @@ export class SegmentState {
     }
   }
 
+  toString(): string {
+    const segment: Segment = this.toSegment()
+    const words = segment.words.filter((w: Word) => w.value).map(
+      (w: Word) => ({value:w.value, index:w.index})
+    )
+    const cleanSegment = {...segment, ...{words,}};
+    return JSON.stringify(cleanSegment, null, 2);
+  }
+
   updateTranscript(words: Word[]): SegmentState {
     words.forEach(w => {
       // Only accept tentative words if the segment is tentative.

--- a/src/speechly/segment.ts
+++ b/src/speechly/segment.ts
@@ -33,11 +33,9 @@ export class SegmentState {
 
   toString(): string {
     const segment: Segment = this.toSegment()
-    const words = segment.words.filter((w: Word) => w.value).map(
-      (w: Word) => ({value:w.value, index:w.index})
-    )
-    const cleanSegment = {...segment, ...{words,}};
-    return JSON.stringify(cleanSegment, null, 2);
+    const words = segment.words.filter((w: Word) => w.value).map((w: Word) => ({ value: w.value, index: w.index }))
+    const cleanSegment = { ...segment, ...{ words } }
+    return JSON.stringify(cleanSegment, null, 2)
   }
 
   updateTranscript(words: Word[]): SegmentState {

--- a/src/speechly/types.ts
+++ b/src/speechly/types.ts
@@ -43,6 +43,11 @@ export interface ClientOptions {
   debug?: boolean
 
   /**
+   * Whether to output updated segments to the console.
+   */
+  logSegments?: boolean
+
+  /**
    * Custom microphone implementation.
    * If not provided, an implementation based on getUserMedia and Web Audio API is used.
    */

--- a/src/websocket/token.test.ts
+++ b/src/websocket/token.test.ts
@@ -54,19 +54,51 @@ describe('token', () => {
 
   describe('.validateToken', () => {
     test('returns true for correct token', () => {
-      expect(validateToken(testTokenString, testToken.projectId, testToken.appId, testToken.deviceId, beforeExpiry(testToken))).toBeTruthy()
+      expect(
+        validateToken(
+          testTokenString,
+          testToken.projectId,
+          testToken.appId,
+          testToken.deviceId,
+          beforeExpiry(testToken),
+        ),
+      ).toBeTruthy()
     })
 
     test('returns false when projectId and appId does not match', () => {
-      expect(validateToken(testTokenString, 'other-app-id', testToken.projectId, testToken.deviceId, beforeExpiry(testToken))).toBeFalsy()
+      expect(
+        validateToken(
+          testTokenString,
+          'other-app-id',
+          testToken.projectId,
+          testToken.deviceId,
+          beforeExpiry(testToken),
+        ),
+      ).toBeFalsy()
     })
 
     test('returns false when deviceId does not match', () => {
-      expect(validateToken(testTokenString, testToken.projectId, testToken.appId, 'other-device-id', beforeExpiry(testToken))).toBeFalsy()
+      expect(
+        validateToken(
+          testTokenString,
+          testToken.projectId,
+          testToken.appId,
+          'other-device-id',
+          beforeExpiry(testToken),
+        ),
+      ).toBeFalsy()
     })
 
     test('returns false when token is expired', () => {
-      expect(validateToken(testTokenString, testToken.projectId, testToken.appId, testToken.deviceId, afterExpiry(testToken))).toBeFalsy()
+      expect(
+        validateToken(
+          testTokenString,
+          testToken.projectId,
+          testToken.appId,
+          testToken.deviceId,
+          afterExpiry(testToken),
+        ),
+      ).toBeFalsy()
     })
   })
 

--- a/src/websocket/token.ts
+++ b/src/websocket/token.ts
@@ -56,7 +56,13 @@ export async function fetchToken(
   return json.access_token
 }
 
-export function validateToken(token: string, projectId: string | undefined, appId: string | undefined, deviceId: string, now: nowFn = Date.now): boolean {
+export function validateToken(
+  token: string,
+  projectId: string | undefined,
+  appId: string | undefined,
+  deviceId: string,
+  now: nowFn = Date.now,
+): boolean {
   const decoded = decodeToken(token)
   if (decoded.expiresAtMs - now() < minTokenValidTime) {
     return false

--- a/src/websocket/token.ts
+++ b/src/websocket/token.ts
@@ -62,7 +62,7 @@ export function validateToken(token: string, projectId: string | undefined, appI
     return false
   }
 
-  if (decoded.appId !== appId && decoded.projectId !== projectId) {
+  if (decoded.appId !== appId || decoded.projectId !== projectId) {
     return false
   }
 

--- a/src/websocket/webWorkerController.ts
+++ b/src/websocket/webWorkerController.ts
@@ -33,7 +33,7 @@ export class WebWorkerController implements APIClient {
       sourceSampleRate,
     })
 
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       this.resolveInitialization = resolve
     })
   }


### PR DESCRIPTION
### What

Provide optional parameter `logSegments` for `ClientOptions`. When true, log the string json representation of the segment updates to browser console. Here is an example of one segment update for an segment with multiple words:

```
{
  "id": 0,
  "contextId": "71b...b6",
  "isFinal": true,
  "words": [
    {
      "value": "PUT",
      "index": 2
    },
    {
      "value": "ON",
      "index": 3
    },
    {
      "value": "THE",
      "index": 4
    },
    {
      "value": "LIGHTS",
      "index": 5
    },
    {
      "value": "IN",
      "index": 6
    },
    {
      "value": "THE",
      "index": 7
    },
    {
      "value": "LIVING",
      "index": 8
    },
    {
      "value": "ROOM",
      "index": 9
    }
  ],
  "entities": [
    {
      "type": "device",
      "value": "LIGHTS",
      "startPosition": 5,
      "endPosition": 6,
      "isFinal": true
    },
    {
      "type": "room",
      "value": "LIVING ROOM",
      "startPosition": 8,
      "endPosition": 10,
      "isFinal": true
    }
  ],
  "intent": {
    "intent": "turn_on",
    "isFinal": true
  }
}
```
By default this is not active.

Also fix an issue when changing app id without providing project id.

### Why

The segment logging feature gives higher level debugging view, than `debug=true`. This is useful when creating apps with browser client.

