### PR TITLE
Allow language codes with M49 regions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/browser-client",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Browser client for Speechly API",
   "private": true,
   "keywords": [

--- a/src/speechly/client.ts
+++ b/src/speechly/client.ts
@@ -106,7 +106,7 @@ export class Client {
     }
 
     const language = options.language ?? defaultLanguage
-    if (!localeCode.validate(language)) {
+    if (!(localeCode.validate(language) || (localeCode.validateLanguageCode(`${language.substring(0, 2)}-XX`) && /^..-\d\d\d$/.test(language)))) {
       throw Error(`[SpeechlyClient] Invalid language "${language}"`)
     }
 


### PR DESCRIPTION
### What

Relaxes the client side validation to allow IETF BCP47 language codes consisting of a ISO 639-1 language code and a UN M49 region code. Currently only ISO 3166‑1 country codes are allowed for the region part.

### Why

To allow such codes should to be used if needed.

